### PR TITLE
Enabling contentful environments, upgrade to CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ yarn add contentful-vue
 ```
 
 ## Useage
-Inside main.js
+Inside main.js.  If you don't declare an environment ID, it will default to `master`.
 ```javascript
 import ContentfulVue from 'contentful-vue';
 
 Vue.use(ContentfulVue, {
   space: YOUR - SPACE,
-  accessToken: YOUR - ACCESS - TOKEN
+  accessToken: YOUR - ACCESS - TOKEN,
+  environment: YOUR - ENVIRONMENT - ID
 });
 ```
 Now inside any Vue component you can `this.$contentful` to access the Contentful API.

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const ContentfulVue = {
     client = Contentful.createClient({
       space: options.space,
       accessToken: options.accessToken,
+      environment: options.environment || 'master',
     });
 
     Vue.prototype.$contentful = client;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "contentful": "^5.1.3"
+    "contentful": "^7.14.8"
   }
 }


### PR DESCRIPTION
Enables the ability to select a custom environment ID for the `createClient()` call with 'master' as a default fallback.  The Contentful module needed to be upgraded to v7 for this to work.